### PR TITLE
Core update

### DIFF
--- a/src/telliot_core/utils/key_helpers.py
+++ b/src/telliot_core/utils/key_helpers.py
@@ -1,4 +1,5 @@
 import getpass
+import os
 
 from chained_accounts import ChainedAccount
 from hexbytes import HexBytes
@@ -18,15 +19,31 @@ def lazy_unlock_account(account: ChainedAccount) -> None:
     if account.is_unlocked:
         return
     else:
-        # Try unlocking with no password
+        # Try unlocking with empty password
         try:
             account.unlock("")
+            return
         except ValueError:
+
+            if os.getenv("PASSWORD"):
+                try:
+                    os.getenv("PASSWORD")
+                    print(f'PASSWORD .env set. Using it to {account.name} unlock.')
+                    account.unlock(str(os.getenv("PASSWORD")))
+                    print(f'Acc {account.name} unlocked with .env PASSWORD')
+                    return
+                except ValueError:
+                    print("Password from .env unlock failed.")
             try:
+                print('Need manual input to unlock account')
                 password = getpass.getpass(f"Enter encryption password for {account.name}: ")
                 account.unlock(password)
+                return
             except ValueError:
                 raise Exception(f"Invalid password for {account.name}")
+            except Exception as e:
+                print(f"An unexpected error occurred: {e}")
+                raise
 
 
 def lazy_key_getter(account: ChainedAccount) -> HexBytes:


### PR DESCRIPTION
Use password to unlock acc from .env
It's the same as --password, --pwd flags, but no need to retype or
wait for certain scenarios to unlock the account.
